### PR TITLE
CloudEvents - Add WebSocket option

### DIFF
--- a/cloudevents/build.gradle
+++ b/cloudevents/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     compileOnly 'jakarta.ws.rs:jakarta.ws.rs-api:2.1.6'
     implementation 'io.cloudevents:cloudevents-http-restful-ws:2.5.0'
     implementation 'io.cloudevents:cloudevents-json-jackson:2.5.0'
+    implementation 'org.java-websocket:Java-WebSocket:1.5.4'
+
 }
 
 group = 'io.github.guacamole_operator'
@@ -26,6 +28,7 @@ java.targetCompatibility = JavaVersion.VERSION_1_8
 shadowJar {
   dependencies {
     exclude(dependency('jakarta.ws.rs:jakarta.ws.rs-api:.*'))
+    exclude(dependency('org.slf4j:.*:.*'))
   }
 }
 

--- a/cloudevents/src/main/java/io/github/guacamole_operator/cloudevents/CloudEventSender.java
+++ b/cloudevents/src/main/java/io/github/guacamole_operator/cloudevents/CloudEventSender.java
@@ -5,12 +5,13 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
 import io.cloudevents.CloudEvent;
+import io.cloudevents.jackson.JsonFormat;
 
 public class CloudEventSender {
     public Response sendEventAsStructured(WebTarget target, CloudEvent event) {
         return target
                 .request()
-                .buildPost(Entity.entity(event, "application/cloudevents+json"))
+                .buildPost(Entity.entity(event, JsonFormat.CONTENT_TYPE))
                 .invoke();
     }
 }

--- a/cloudevents/src/main/java/io/github/guacamole_operator/cloudevents/Properties.java
+++ b/cloudevents/src/main/java/io/github/guacamole_operator/cloudevents/Properties.java
@@ -1,6 +1,7 @@
 package io.github.guacamole_operator.cloudevents;
 
 import org.apache.guacamole.properties.BooleanGuacamoleProperty;
+import org.apache.guacamole.properties.IntegerGuacamoleProperty;
 import org.apache.guacamole.properties.StringGuacamoleProperty;
 
 public class Properties {
@@ -25,6 +26,23 @@ public class Properties {
         }
     };
 
+    public static final BooleanGuacamoleProperty WEBSOCKETS_ENABLE = new BooleanGuacamoleProperty() {
+        @Override
+        public String getName() {
+            return "cloudevents-websockets-enable";
+        }
+    };
+
+    public static final IntegerGuacamoleProperty WEBSOCKETS_PORT = new IntegerGuacamoleProperty() {
+        @Override
+        public String getName() {
+            return "cloudevents-websockets-port";
+        }
+    };
+
     public static final String DEFAULT_SOURCE = "/cloudevents";
     public static final boolean DEFAULT_TLS_VERIFY = true;
+    public static final boolean DEFAULT_WEBSOCKETS_ENABLE = false;
+    public static final int DEFAULT_WEBSOCKETS_PORT = 8081;
+
 }

--- a/cloudevents/src/main/java/io/github/guacamole_operator/cloudevents/WebSocketServerImpl.java
+++ b/cloudevents/src/main/java/io/github/guacamole_operator/cloudevents/WebSocketServerImpl.java
@@ -1,0 +1,51 @@
+package io.github.guacamole_operator.cloudevents;
+
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+
+import org.java_websocket.WebSocket;
+import org.java_websocket.handshake.ClientHandshake;
+import org.java_websocket.server.WebSocketServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebSocketServerImpl extends WebSocketServer {
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketServerImpl.class);
+    private final int port;
+
+    public WebSocketServerImpl(int port) {
+        super(new InetSocketAddress(port));
+        this.port = port;
+    }
+
+    @Override
+    public void onOpen(WebSocket conn, ClientHandshake handshake) {
+        logger.info("New WebSocket connection to {}.", conn.getRemoteSocketAddress());
+    }
+
+    @Override
+    public void onClose(WebSocket conn, int code, String reason, boolean remote) {
+        logger.info("WebSocket connection closed for {} with exit code {}. Additional info: {}.",
+                conn.getRemoteSocketAddress(), code, reason);
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, String message) {
+        // Nothing to do.
+    }
+
+    @Override
+    public void onMessage(WebSocket conn, ByteBuffer message) {
+        // Nothing to do.
+    }
+
+    @Override
+    public void onError(WebSocket conn, Exception ex) {
+        logger.error("an error occurred on connection {}.", conn.getRemoteSocketAddress(), ex);
+    }
+
+    @Override
+    public void onStart() {
+        logger.info("WebSocket server started on :{}.", this.port);
+    }
+}


### PR DESCRIPTION
Ability to send CloudEvents via websocket added. As it was not possible as of now to use JSR356 with the extension model of Guacamole, a separate WebSocket server is started in this case. No authorization takes place for WebSockets.